### PR TITLE
Changing meganav-card colour style due to nuglify issue in prod

### DIFF
--- a/src/Our.Umbraco.Meganav/Web/UI/App_Plugins/Meganav/backoffice/meganav.css
+++ b/src/Our.Umbraco.Meganav/Web/UI/App_Plugins/Meganav/backoffice/meganav.css
@@ -27,7 +27,7 @@
     width: 100%;
     background-color: #fff;
     border-radius: 6px;
-    box-shadow: 0 1px 2px rgb(0 0 0 / 20%);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, .2);
     cursor: pointer;
 }
 


### PR DESCRIPTION
A minor tweak due to an issue we encounter with Meganav CSS nuglify minification when running in production.

The Umbraco backoffice uses Smidge/Nuglify to compile/minify the backoffice CSS but this is failing when ran in production due to one line in the Meganav backoffice stylesheet. This change is a very minor tweak to that line to resolve this issue without effecting the UI.

The error in production environments (does not occur in dev):
`System.InvalidOperationException: Expected closing parenthesis, found ',',Expected function, found ',',Expected semicolon or closing curly-brace, found ')'
   at Smidge.Nuglify.NuglifyCss.ProcessAsync(FileProcessContext fileProcessContext, PreProcessorDelegate next)
   at Smidge.FileProcessors.PreProcessPipeline.ProcessNext(Queue1 queue, FileProcessContext fileProcessContext)
   at Smidge.FileProcessors.PreProcessPipeline.<>c__DisplayClass5_0.<<ProcessNext>b__0>d.MoveNext()`

A similar error is reported here (albeit this user is not using Meganav):
https://our.umbraco.com/forum/using-umbraco-and-getting-started/108469-backofficeadmin-css-smidgenuglify-error-breaking-package-styling

To replicate try running in a production environment so the Umbraco backoffice will compile/minify backoffice CSS and note the backoffice CSS styling is broken and will return an error 500. You should also see an error log similar to above in the Umbraco log.

